### PR TITLE
Switch from surface2 to overlay1 for comments

### DIFF
--- a/italics/catppuccin_frappe.toml
+++ b/italics/catppuccin_frappe.toml
@@ -9,7 +9,7 @@
 "string" = "green"
 "string.regexp" = "peach"
 "string.special" = "pink"
-"comment" = { fg = "surface2", modifiers = ["italic"] }
+"comment" = { fg = "overlay1", modifiers = ["italic"] }
 "variable" = "text"
 "variable.parameter" = { fg = "maroon", modifiers = ["italic"] }
 "variable.builtin" = "red"

--- a/italics/catppuccin_latte.toml
+++ b/italics/catppuccin_latte.toml
@@ -9,7 +9,7 @@
 "string" = "green"
 "string.regexp" = "peach"
 "string.special" = "pink"
-"comment" = { fg = "surface2", modifiers = ["italic"] }
+"comment" = { fg = "overlay1", modifiers = ["italic"] }
 "variable" = "text"
 "variable.parameter" = { fg = "maroon", modifiers = ["italic"] }
 "variable.builtin" = "red"

--- a/italics/catppuccin_macchiato.toml
+++ b/italics/catppuccin_macchiato.toml
@@ -9,7 +9,7 @@
 "string" = "green"
 "string.regexp" = "peach"
 "string.special" = "pink"
-"comment" = { fg = "surface2", modifiers = ["italic"] }
+"comment" = { fg = "overlay1", modifiers = ["italic"] }
 "variable" = "text"
 "variable.parameter" = { fg = "maroon", modifiers = ["italic"] }
 "variable.builtin" = "red"

--- a/italics/catppuccin_mocha.toml
+++ b/italics/catppuccin_mocha.toml
@@ -9,7 +9,7 @@
 "string" = "green"
 "string.regexp" = "peach"
 "string.special" = "pink"
-"comment" = { fg = "surface2", modifiers = ["italic"] }
+"comment" = { fg = "overlay1", modifiers = ["italic"] }
 "variable" = "text"
 "variable.parameter" = { fg = "maroon", modifiers = ["italic"] }
 "variable.builtin" = "red"

--- a/no_italics/catppuccin_frappe.toml
+++ b/no_italics/catppuccin_frappe.toml
@@ -9,7 +9,7 @@
 "string" = "green"
 "string.regexp" = "peach"
 "string.special" = "pink"
-"comment" = { fg = "surface2" }
+"comment" = { fg = "overlay1" }
 "variable" = "text"
 "variable.parameter" = { fg = "maroon" }
 "variable.builtin" = "red"

--- a/no_italics/catppuccin_latte.toml
+++ b/no_italics/catppuccin_latte.toml
@@ -9,7 +9,7 @@
 "string" = "green"
 "string.regexp" = "peach"
 "string.special" = "pink"
-"comment" = { fg = "surface2" }
+"comment" = { fg = "overlay1" }
 "variable" = "text"
 "variable.parameter" = { fg = "maroon" }
 "variable.builtin" = "red"

--- a/no_italics/catppuccin_macchiato.toml
+++ b/no_italics/catppuccin_macchiato.toml
@@ -9,7 +9,7 @@
 "string" = "green"
 "string.regexp" = "peach"
 "string.special" = "pink"
-"comment" = { fg = "surface2" }
+"comment" = { fg = "overlay1" }
 "variable" = "text"
 "variable.parameter" = { fg = "maroon" }
 "variable.builtin" = "red"

--- a/no_italics/catppuccin_mocha.toml
+++ b/no_italics/catppuccin_mocha.toml
@@ -9,7 +9,7 @@
 "string" = "green"
 "string.regexp" = "peach"
 "string.special" = "pink"
-"comment" = { fg = "surface2" }
+"comment" = { fg = "overlay1" }
 "variable" = "text"
 "variable.parameter" = { fg = "maroon" }
 "variable.builtin" = "red"


### PR DESCRIPTION
Looking at https://github.com/catppuccin/catppuccin/blob/dev/docs/style-guide.md, I believe comments should be styled with overlay1, not surface2. At the very least, surface2 was tough to read for me.