### PR TITLE
Restore comment being overlay1 in templates

### DIFF
--- a/data/template.tmpl
+++ b/data/template.tmpl
@@ -13,7 +13,7 @@
 "string.regexp" = "peach"
 "string.special" = "blue"
 
-"comment" = {{ fg = "surface2"{styles[comments]} }}
+"comment" = {{ fg = "overlay1"{styles[comments]} }}
 
 "variable" = "text"
 "variable.parameter" = {{ fg = "maroon"{styles[parameters]} }}

--- a/themes/default/catppuccin_frappe.toml
+++ b/themes/default/catppuccin_frappe.toml
@@ -13,7 +13,7 @@
 "string.regexp" = "peach"
 "string.special" = "blue"
 
-"comment" = { fg = "surface2", modifiers = ["italic"] }
+"comment" = { fg = "overlay1", modifiers = ["italic"] }
 
 "variable" = "text"
 "variable.parameter" = { fg = "maroon", modifiers = ["italic"] }

--- a/themes/default/catppuccin_latte.toml
+++ b/themes/default/catppuccin_latte.toml
@@ -13,7 +13,7 @@
 "string.regexp" = "peach"
 "string.special" = "blue"
 
-"comment" = { fg = "surface2", modifiers = ["italic"] }
+"comment" = { fg = "overlay1", modifiers = ["italic"] }
 
 "variable" = "text"
 "variable.parameter" = { fg = "maroon", modifiers = ["italic"] }

--- a/themes/default/catppuccin_macchiato.toml
+++ b/themes/default/catppuccin_macchiato.toml
@@ -13,7 +13,7 @@
 "string.regexp" = "peach"
 "string.special" = "blue"
 
-"comment" = { fg = "surface2", modifiers = ["italic"] }
+"comment" = { fg = "overlay1", modifiers = ["italic"] }
 
 "variable" = "text"
 "variable.parameter" = { fg = "maroon", modifiers = ["italic"] }

--- a/themes/default/catppuccin_mocha.toml
+++ b/themes/default/catppuccin_mocha.toml
@@ -13,7 +13,7 @@
 "string.regexp" = "peach"
 "string.special" = "blue"
 
-"comment" = { fg = "surface2", modifiers = ["italic"] }
+"comment" = { fg = "overlay1", modifiers = ["italic"] }
 
 "variable" = "text"
 "variable.parameter" = { fg = "maroon", modifiers = ["italic"] }

--- a/themes/no_italics/catppuccin_frappe.toml
+++ b/themes/no_italics/catppuccin_frappe.toml
@@ -13,7 +13,7 @@
 "string.regexp" = "peach"
 "string.special" = "blue"
 
-"comment" = { fg = "surface2" }
+"comment" = { fg = "overlay1" }
 
 "variable" = "text"
 "variable.parameter" = { fg = "maroon" }

--- a/themes/no_italics/catppuccin_latte.toml
+++ b/themes/no_italics/catppuccin_latte.toml
@@ -13,7 +13,7 @@
 "string.regexp" = "peach"
 "string.special" = "blue"
 
-"comment" = { fg = "surface2" }
+"comment" = { fg = "overlay1" }
 
 "variable" = "text"
 "variable.parameter" = { fg = "maroon" }

--- a/themes/no_italics/catppuccin_macchiato.toml
+++ b/themes/no_italics/catppuccin_macchiato.toml
@@ -13,7 +13,7 @@
 "string.regexp" = "peach"
 "string.special" = "blue"
 
-"comment" = { fg = "surface2" }
+"comment" = { fg = "overlay1" }
 
 "variable" = "text"
 "variable.parameter" = { fg = "maroon" }

--- a/themes/no_italics/catppuccin_mocha.toml
+++ b/themes/no_italics/catppuccin_mocha.toml
@@ -13,7 +13,7 @@
 "string.regexp" = "peach"
 "string.special" = "blue"
 
-"comment" = { fg = "surface2" }
+"comment" = { fg = "overlay1" }
 
 "variable" = "text"
 "variable.parameter" = { fg = "maroon" }


### PR DESCRIPTION
https://github.com/catppuccin/helix/pull/6 changed comments to use overlay1 instead of surface2. That fix was lost in the switch to generating from a template. Restore that fix in the templates and regenerate.