### PR TITLE
Remove Italic from Markdown URLs

### DIFF
--- a/data/configs/default.json
+++ b/data/configs/default.json
@@ -11,6 +11,10 @@
     ],
     "namespaces": [
       "italic"
+    ],
+    "markup_link_url": [
+      "italic",
+      "underlined"
     ]
   }
 }

--- a/data/configs/no_italics.json
+++ b/data/configs/no_italics.json
@@ -3,6 +3,9 @@
     "comments": null,
     "conditionals": null,
     "parameters": null,
-    "namespaces": null
+    "namespaces": null,
+    "markup_link_url": [
+      "underlined"
+    ]
   }
 }

--- a/data/template.tmpl
+++ b/data/template.tmpl
@@ -50,7 +50,7 @@
 "markup.list" = "mauve"
 "markup.bold" = {{ modifiers = ["bold"] }}
 "markup.italic" = {{ modifiers = ["italic"] }}
-"markup.link.url" = {{ fg = "rosewater", modifiers = ["italic", "underlined"] }}
+"markup.link.url" = {{ fg = "rosewater"{styles[markup_link_url]} }}
 "markup.link.text" = "blue"
 "markup.raw" = "flamingo"
 

--- a/themes/no_italics/catppuccin_frappe.toml
+++ b/themes/no_italics/catppuccin_frappe.toml
@@ -50,7 +50,7 @@
 "markup.list" = "mauve"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
-"markup.link.url" = { fg = "rosewater", modifiers = ["italic", "underlined"] }
+"markup.link.url" = { fg = "rosewater", modifiers = ["underlined"] }
 "markup.link.text" = "blue"
 "markup.raw" = "flamingo"
 

--- a/themes/no_italics/catppuccin_latte.toml
+++ b/themes/no_italics/catppuccin_latte.toml
@@ -50,7 +50,7 @@
 "markup.list" = "mauve"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
-"markup.link.url" = { fg = "rosewater", modifiers = ["italic", "underlined"] }
+"markup.link.url" = { fg = "rosewater", modifiers = ["underlined"] }
 "markup.link.text" = "blue"
 "markup.raw" = "flamingo"
 

--- a/themes/no_italics/catppuccin_macchiato.toml
+++ b/themes/no_italics/catppuccin_macchiato.toml
@@ -50,7 +50,7 @@
 "markup.list" = "mauve"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
-"markup.link.url" = { fg = "rosewater", modifiers = ["italic", "underlined"] }
+"markup.link.url" = { fg = "rosewater", modifiers = ["underlined"] }
 "markup.link.text" = "blue"
 "markup.raw" = "flamingo"
 

--- a/themes/no_italics/catppuccin_mocha.toml
+++ b/themes/no_italics/catppuccin_mocha.toml
@@ -50,7 +50,7 @@
 "markup.list" = "mauve"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }
-"markup.link.url" = { fg = "rosewater", modifiers = ["italic", "underlined"] }
+"markup.link.url" = { fg = "rosewater", modifiers = ["underlined"] }
 "markup.link.text" = "blue"
 "markup.raw" = "flamingo"
 


### PR DESCRIPTION
This removes the italic modifier from URLs in markdown files for the no_italics themes.