### PR TITLE
Fix Shield URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 </h3>
 
 <p align="center">
-    <a href="https://github.com/catppuccin/helix/stargazers"><img src="https://img.shields.io/github/stars/catppuccin/dunst?colorA=363a4f&colorB=b7bdf8&style=for-the-badge"></a>
-    <a href="https://github.com/catppuccin/helix/issues"><img src="https://img.shields.io/github/issues/catppuccin/dunst?colorA=363a4f&colorB=f5a97f&style=for-the-badge"></a>
-    <a href="https://github.com/catppuccin/helix/contributors"><img src="https://img.shields.io/github/contributors/catppuccin/dunst?colorA=363a4f&colorB=a6da95&style=for-the-badge"></a>
+    <a href="https://github.com/catppuccin/helix/stargazers"><img src="https://img.shields.io/github/stars/catppuccin/helix?colorA=363a4f&colorB=b7bdf8&style=for-the-badge"></a>
+    <a href="https://github.com/catppuccin/helix/issues"><img src="https://img.shields.io/github/issues/catppuccin/helix?colorA=363a4f&colorB=f5a97f&style=for-the-badge"></a>
+    <a href="https://github.com/catppuccin/helix/contributors"><img src="https://img.shields.io/github/contributors/catppuccin/helix?colorA=363a4f&colorB=a6da95&style=for-the-badge"></a>
 </p>
 
 ![helix preview](assets/preview.webp)


### PR DESCRIPTION
The old shields in the README were pointing to the dunst project. I updated them to point to this project.