### PR TITLE
redesign theme bufferline

### DIFF
--- a/data/template.tmpl
+++ b/data/template.tmpl
@@ -75,11 +75,11 @@
 "ui.window" = {{ fg = "crust" }}
 "ui.help" = {{ fg = "overlay2", bg = "surface0" }}
 
-"ui.bufferline" = {{ fg = "surface1", bg = "mantle" }}
-"ui.bufferline.active" = {{ fg = "text", bg = "base", modifiers = ["bold", "italic"] }}
-"ui.bufferline.background" = {{ bg = "surface0" }}
+"ui.bufferline" = {{ fg = "subtext0", bg = "mantle" }}
+"ui.bufferline.active" = {{ fg = "text", bg = "base", modifiers = ["bold"] }}
+"ui.bufferline.background" = {{ bg = "crust" }}
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = {{ fg = "text", bg = "surface0", modifiers = ["bold"] }}
 
 "ui.virtual" = "overlay0"

--- a/themes/default/catppuccin_frappe.toml
+++ b/themes/default/catppuccin_frappe.toml
@@ -75,11 +75,11 @@
 "ui.window" = { fg = "crust" }
 "ui.help" = { fg = "overlay2", bg = "surface0" }
 
-"ui.bufferline" = { fg = "surface1", bg = "mantle" }
-"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
-"ui.bufferline.background" = { bg = "surface0" }
+"ui.bufferline" = { fg = "subtext0", bg = "mantle" }
+"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "crust" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"

--- a/themes/default/catppuccin_latte.toml
+++ b/themes/default/catppuccin_latte.toml
@@ -75,11 +75,11 @@
 "ui.window" = { fg = "crust" }
 "ui.help" = { fg = "overlay2", bg = "surface0" }
 
-"ui.bufferline" = { fg = "surface1", bg = "mantle" }
-"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
-"ui.bufferline.background" = { bg = "surface0" }
+"ui.bufferline" = { fg = "subtext0", bg = "mantle" }
+"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "crust" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"

--- a/themes/default/catppuccin_macchiato.toml
+++ b/themes/default/catppuccin_macchiato.toml
@@ -75,11 +75,11 @@
 "ui.window" = { fg = "crust" }
 "ui.help" = { fg = "overlay2", bg = "surface0" }
 
-"ui.bufferline" = { fg = "surface1", bg = "mantle" }
-"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
-"ui.bufferline.background" = { bg = "surface0" }
+"ui.bufferline" = { fg = "subtext0", bg = "mantle" }
+"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "crust" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"

--- a/themes/default/catppuccin_mocha.toml
+++ b/themes/default/catppuccin_mocha.toml
@@ -75,11 +75,11 @@
 "ui.window" = { fg = "crust" }
 "ui.help" = { fg = "overlay2", bg = "surface0" }
 
-"ui.bufferline" = { fg = "surface1", bg = "mantle" }
-"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
-"ui.bufferline.background" = { bg = "surface0" }
+"ui.bufferline" = { fg = "subtext0", bg = "mantle" }
+"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "crust" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"

--- a/themes/no_italics/catppuccin_frappe.toml
+++ b/themes/no_italics/catppuccin_frappe.toml
@@ -75,11 +75,11 @@
 "ui.window" = { fg = "crust" }
 "ui.help" = { fg = "overlay2", bg = "surface0" }
 
-"ui.bufferline" = { fg = "surface1", bg = "mantle" }
-"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
-"ui.bufferline.background" = { bg = "surface0" }
+"ui.bufferline" = { fg = "subtext0", bg = "mantle" }
+"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "crust" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"

--- a/themes/no_italics/catppuccin_latte.toml
+++ b/themes/no_italics/catppuccin_latte.toml
@@ -75,11 +75,11 @@
 "ui.window" = { fg = "crust" }
 "ui.help" = { fg = "overlay2", bg = "surface0" }
 
-"ui.bufferline" = { fg = "surface1", bg = "mantle" }
-"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
-"ui.bufferline.background" = { bg = "surface0" }
+"ui.bufferline" = { fg = "subtext0", bg = "mantle" }
+"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "crust" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"

--- a/themes/no_italics/catppuccin_macchiato.toml
+++ b/themes/no_italics/catppuccin_macchiato.toml
@@ -75,11 +75,11 @@
 "ui.window" = { fg = "crust" }
 "ui.help" = { fg = "overlay2", bg = "surface0" }
 
-"ui.bufferline" = { fg = "surface1", bg = "mantle" }
-"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
-"ui.bufferline.background" = { bg = "surface0" }
+"ui.bufferline" = { fg = "subtext0", bg = "mantle" }
+"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "crust" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"

--- a/themes/no_italics/catppuccin_mocha.toml
+++ b/themes/no_italics/catppuccin_mocha.toml
@@ -75,11 +75,11 @@
 "ui.window" = { fg = "crust" }
 "ui.help" = { fg = "overlay2", bg = "surface0" }
 
-"ui.bufferline" = { fg = "surface1", bg = "mantle" }
-"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
-"ui.bufferline.background" = { bg = "surface0" }
+"ui.bufferline" = { fg = "subtext0", bg = "mantle" }
+"ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "crust" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"


### PR DESCRIPTION
Fixes: #24
Fixes: #10

Guiding https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md active buffer should be styled with `base`, inactive buffers with `mantle` and background `crust`

latte:
![image](https://user-images.githubusercontent.com/116971836/224474618-6fb245f0-5688-4e41-b754-5b4396a330ac.png)
mocha:
![image](https://user-images.githubusercontent.com/116971836/224474648-b5e06cf2-fefb-4c40-a9c7-97cee06d313b.png)
frappe:
![image](https://user-images.githubusercontent.com/116971836/224474655-a00f1005-6cfc-461e-9a49-e75ea7d70877.png)
macchiato
![image](https://user-images.githubusercontent.com/116971836/224474661-8b759afc-477a-4a8c-b24d-96173c719840.png)


