### PR TITLE
remove theme `function.builtin`

### DIFF
--- a/data/template.tmpl
+++ b/data/template.tmpl
@@ -31,7 +31,6 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.builtin" = "peach"
 "function.macro" = "mauve"
 
 "tag" = "mauve"
@@ -79,7 +78,7 @@
 "ui.bufferline.active" = {{ fg = "text", bg = "base", modifiers = ["bold", "italic"] }}
 "ui.bufferline.background" = {{ bg = "surface0" }}
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = {{ fg = "text", bg = "surface0", modifiers = ["bold"] }}
 
 "ui.virtual" = "overlay0"

--- a/themes/default/catppuccin_frappe.toml
+++ b/themes/default/catppuccin_frappe.toml
@@ -31,7 +31,6 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.builtin" = "peach"
 "function.macro" = "mauve"
 
 "tag" = "mauve"
@@ -79,7 +78,7 @@
 "ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
 "ui.bufferline.background" = { bg = "surface0" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"

--- a/themes/default/catppuccin_latte.toml
+++ b/themes/default/catppuccin_latte.toml
@@ -31,7 +31,6 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.builtin" = "peach"
 "function.macro" = "mauve"
 
 "tag" = "mauve"
@@ -79,7 +78,7 @@
 "ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
 "ui.bufferline.background" = { bg = "surface0" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"

--- a/themes/default/catppuccin_macchiato.toml
+++ b/themes/default/catppuccin_macchiato.toml
@@ -31,7 +31,6 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.builtin" = "peach"
 "function.macro" = "mauve"
 
 "tag" = "mauve"
@@ -79,7 +78,7 @@
 "ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
 "ui.bufferline.background" = { bg = "surface0" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"

--- a/themes/default/catppuccin_mocha.toml
+++ b/themes/default/catppuccin_mocha.toml
@@ -31,7 +31,6 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.builtin" = "peach"
 "function.macro" = "mauve"
 
 "tag" = "mauve"
@@ -79,7 +78,7 @@
 "ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
 "ui.bufferline.background" = { bg = "surface0" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"

--- a/themes/no_italics/catppuccin_frappe.toml
+++ b/themes/no_italics/catppuccin_frappe.toml
@@ -31,7 +31,6 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.builtin" = "peach"
 "function.macro" = "mauve"
 
 "tag" = "mauve"
@@ -79,7 +78,7 @@
 "ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
 "ui.bufferline.background" = { bg = "surface0" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"

--- a/themes/no_italics/catppuccin_latte.toml
+++ b/themes/no_italics/catppuccin_latte.toml
@@ -31,7 +31,6 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.builtin" = "peach"
 "function.macro" = "mauve"
 
 "tag" = "mauve"
@@ -79,7 +78,7 @@
 "ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
 "ui.bufferline.background" = { bg = "surface0" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"

--- a/themes/no_italics/catppuccin_macchiato.toml
+++ b/themes/no_italics/catppuccin_macchiato.toml
@@ -31,7 +31,6 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.builtin" = "peach"
 "function.macro" = "mauve"
 
 "tag" = "mauve"
@@ -79,7 +78,7 @@
 "ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
 "ui.bufferline.background" = { bg = "surface0" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"

--- a/themes/no_italics/catppuccin_mocha.toml
+++ b/themes/no_italics/catppuccin_mocha.toml
@@ -31,7 +31,6 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.builtin" = "peach"
 "function.macro" = "mauve"
 
 "tag" = "mauve"
@@ -79,7 +78,7 @@
 "ui.bufferline.active" = { fg = "text", bg = "base", modifiers = ["bold", "italic"] }
 "ui.bufferline.background" = { bg = "surface0" }
 
-"ui.text" = "text" 
+"ui.text" = "text"
 "ui.text.focus" = { fg = "text", bg = "surface0", modifiers = ["bold"] }
 
 "ui.virtual" = "overlay0"


### PR DESCRIPTION
This PR removes highlight for `function.builtin` and highlight them same as `function`.

See: https://github.com/catppuccin/helix/issues/17#issue-1530744754

> (Also I just noticed function color is different and I think vscode's is better)