### PR TITLE
Update README to include True Colors setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
 
 1. Helix itself includes the default variant of the theme. For other variants, copy the contents of the `themes/...` folder into `$HOME/.config/helix/themes/` to overwrite.
 2. Choose a palette (latte, frappe, macchiato, mocha) and add `theme = "catppuccin_(palette)"` to your config.toml
-3. (Optional) modify your `$HOME/.config/helix/config.toml` to activate features:
+3. Turn on terminal True Colors by setting `[editor] true-color = true`
+4. (Optional) modify your `$HOME/.config/helix/config.toml` to activate features:
 	```toml
 	[editor]
 	line-number = "relative"


### PR DESCRIPTION
When installing and setting up helix for the first time with `theme = "catppuccin_macchiato"` everytime I opened helix I got the default theme. A bunch of googling pointed towards runtime folder location issues but after a lot of troubleshooting I finally decided to just try different themes with the `:theme` command. I tried loading a different catppuccin theme and I got an error saying I needed to enable true colors. If you follow the instructions in this README when setting up helix for the first time you will not see this error as it only appears when manually selecting a theme through the command (it's not even in the helix logs)