### PR TITLE
feat: highlight namespaces with yellow

### DIFF
--- a/data/template.tmpl
+++ b/data/template.tmpl
@@ -36,7 +36,7 @@
 "tag" = "mauve"
 "attribute" = "blue"
 
-"namespace" = {{ fg = "blue"{styles[namespaces]} }}
+"namespace" = {{ fg = "yellow"{styles[namespaces]} }}
 
 "special" = "blue" # fuzzy highlight
 

--- a/themes/default/catppuccin_frappe.toml
+++ b/themes/default/catppuccin_frappe.toml
@@ -36,7 +36,7 @@
 "tag" = "mauve"
 "attribute" = "blue"
 
-"namespace" = { fg = "blue", modifiers = ["italic"] }
+"namespace" = { fg = "yellow", modifiers = ["italic"] }
 
 "special" = "blue" # fuzzy highlight
 

--- a/themes/default/catppuccin_latte.toml
+++ b/themes/default/catppuccin_latte.toml
@@ -36,7 +36,7 @@
 "tag" = "mauve"
 "attribute" = "blue"
 
-"namespace" = { fg = "blue", modifiers = ["italic"] }
+"namespace" = { fg = "yellow", modifiers = ["italic"] }
 
 "special" = "blue" # fuzzy highlight
 

--- a/themes/default/catppuccin_macchiato.toml
+++ b/themes/default/catppuccin_macchiato.toml
@@ -36,7 +36,7 @@
 "tag" = "mauve"
 "attribute" = "blue"
 
-"namespace" = { fg = "blue", modifiers = ["italic"] }
+"namespace" = { fg = "yellow", modifiers = ["italic"] }
 
 "special" = "blue" # fuzzy highlight
 

--- a/themes/default/catppuccin_mocha.toml
+++ b/themes/default/catppuccin_mocha.toml
@@ -36,7 +36,7 @@
 "tag" = "mauve"
 "attribute" = "blue"
 
-"namespace" = { fg = "blue", modifiers = ["italic"] }
+"namespace" = { fg = "yellow", modifiers = ["italic"] }
 
 "special" = "blue" # fuzzy highlight
 

--- a/themes/no_italics/catppuccin_frappe.toml
+++ b/themes/no_italics/catppuccin_frappe.toml
@@ -36,7 +36,7 @@
 "tag" = "mauve"
 "attribute" = "blue"
 
-"namespace" = { fg = "blue" }
+"namespace" = { fg = "yellow" }
 
 "special" = "blue" # fuzzy highlight
 

--- a/themes/no_italics/catppuccin_latte.toml
+++ b/themes/no_italics/catppuccin_latte.toml
@@ -36,7 +36,7 @@
 "tag" = "mauve"
 "attribute" = "blue"
 
-"namespace" = { fg = "blue" }
+"namespace" = { fg = "yellow" }
 
 "special" = "blue" # fuzzy highlight
 

--- a/themes/no_italics/catppuccin_macchiato.toml
+++ b/themes/no_italics/catppuccin_macchiato.toml
@@ -36,7 +36,7 @@
 "tag" = "mauve"
 "attribute" = "blue"
 
-"namespace" = { fg = "blue" }
+"namespace" = { fg = "yellow" }
 
 "special" = "blue" # fuzzy highlight
 

--- a/themes/no_italics/catppuccin_mocha.toml
+++ b/themes/no_italics/catppuccin_mocha.toml
@@ -36,7 +36,7 @@
 "tag" = "mauve"
 "attribute" = "blue"
 
-"namespace" = { fg = "blue" }
+"namespace" = { fg = "yellow" }
 
 "special" = "blue" # fuzzy highlight
 


### PR DESCRIPTION
before:
![image](https://github.com/catppuccin/helix/assets/289746/128f0487-136f-4a13-bac3-39a6aeecae76)

after:
![image](https://github.com/catppuccin/helix/assets/289746/3ac13e99-e3dc-4f33-bec3-fcf66e49c02c)

closes #36 
