### PR TITLE
fix: use blue instead of teal for variable.other.member

### DIFF
--- a/helix.tera
+++ b/helix.tera
@@ -42,7 +42,7 @@ whiskers:
 "variable" = "text"
 "variable.parameter" = { fg = "maroon"{{ self::modifiers() }} }
 "variable.builtin" = "red"
-"variable.other.member" = "teal"
+"variable.other.member" = "blue"
 
 "label" = "sapphire" # used for lifetimes
 

--- a/themes/default/catppuccin_frappe.toml
+++ b/themes/default/catppuccin_frappe.toml
@@ -21,7 +21,7 @@
 "variable" = "text"
 "variable.parameter" = { fg = "maroon", modifiers = ["italic"] }
 "variable.builtin" = "red"
-"variable.other.member" = "teal"
+"variable.other.member" = "blue"
 
 "label" = "sapphire" # used for lifetimes
 

--- a/themes/default/catppuccin_latte.toml
+++ b/themes/default/catppuccin_latte.toml
@@ -21,7 +21,7 @@
 "variable" = "text"
 "variable.parameter" = { fg = "maroon", modifiers = ["italic"] }
 "variable.builtin" = "red"
-"variable.other.member" = "teal"
+"variable.other.member" = "blue"
 
 "label" = "sapphire" # used for lifetimes
 

--- a/themes/default/catppuccin_macchiato.toml
+++ b/themes/default/catppuccin_macchiato.toml
@@ -21,7 +21,7 @@
 "variable" = "text"
 "variable.parameter" = { fg = "maroon", modifiers = ["italic"] }
 "variable.builtin" = "red"
-"variable.other.member" = "teal"
+"variable.other.member" = "blue"
 
 "label" = "sapphire" # used for lifetimes
 

--- a/themes/default/catppuccin_mocha.toml
+++ b/themes/default/catppuccin_mocha.toml
@@ -21,7 +21,7 @@
 "variable" = "text"
 "variable.parameter" = { fg = "maroon", modifiers = ["italic"] }
 "variable.builtin" = "red"
-"variable.other.member" = "teal"
+"variable.other.member" = "blue"
 
 "label" = "sapphire" # used for lifetimes
 

--- a/themes/no_italics/catppuccin_frappe.toml
+++ b/themes/no_italics/catppuccin_frappe.toml
@@ -21,7 +21,7 @@
 "variable" = "text"
 "variable.parameter" = { fg = "maroon" }
 "variable.builtin" = "red"
-"variable.other.member" = "teal"
+"variable.other.member" = "blue"
 
 "label" = "sapphire" # used for lifetimes
 

--- a/themes/no_italics/catppuccin_latte.toml
+++ b/themes/no_italics/catppuccin_latte.toml
@@ -21,7 +21,7 @@
 "variable" = "text"
 "variable.parameter" = { fg = "maroon" }
 "variable.builtin" = "red"
-"variable.other.member" = "teal"
+"variable.other.member" = "blue"
 
 "label" = "sapphire" # used for lifetimes
 

--- a/themes/no_italics/catppuccin_macchiato.toml
+++ b/themes/no_italics/catppuccin_macchiato.toml
@@ -21,7 +21,7 @@
 "variable" = "text"
 "variable.parameter" = { fg = "maroon" }
 "variable.builtin" = "red"
-"variable.other.member" = "teal"
+"variable.other.member" = "blue"
 
 "label" = "sapphire" # used for lifetimes
 

--- a/themes/no_italics/catppuccin_mocha.toml
+++ b/themes/no_italics/catppuccin_mocha.toml
@@ -21,7 +21,7 @@
 "variable" = "text"
 "variable.parameter" = { fg = "maroon" }
 "variable.builtin" = "red"
-"variable.other.member" = "teal"
+"variable.other.member" = "blue"
 
 "label" = "sapphire" # used for lifetimes
 


### PR DESCRIPTION
Fixes the colors of member properties in objects like the following Nix file. Matches VSCode.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/0060c45a-80b0-426b-bba9-533c61329070) | ![image](https://github.com/user-attachments/assets/084803ec-3550-41f5-ac4b-28f0457d4016) |