### PR TITLE
feat: add diagnostics.unnecessary entry

### DIFF
--- a/helix.tera
+++ b/helix.tera
@@ -140,6 +140,7 @@ whiskers:
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.info" = { underline = { color = "sky", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
 
 error = "red"
 warning = "yellow"

--- a/themes/default/catppuccin_frappe.toml
+++ b/themes/default/catppuccin_frappe.toml
@@ -119,6 +119,7 @@
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.info" = { underline = { color = "sky", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
 
 error = "red"
 warning = "yellow"

--- a/themes/default/catppuccin_latte.toml
+++ b/themes/default/catppuccin_latte.toml
@@ -119,6 +119,7 @@
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.info" = { underline = { color = "sky", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
 
 error = "red"
 warning = "yellow"

--- a/themes/default/catppuccin_macchiato.toml
+++ b/themes/default/catppuccin_macchiato.toml
@@ -119,6 +119,7 @@
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.info" = { underline = { color = "sky", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
 
 error = "red"
 warning = "yellow"

--- a/themes/default/catppuccin_mocha.toml
+++ b/themes/default/catppuccin_mocha.toml
@@ -119,6 +119,7 @@
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.info" = { underline = { color = "sky", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
 
 error = "red"
 warning = "yellow"

--- a/themes/no_italics/catppuccin_frappe.toml
+++ b/themes/no_italics/catppuccin_frappe.toml
@@ -119,6 +119,7 @@
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.info" = { underline = { color = "sky", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
 
 error = "red"
 warning = "yellow"

--- a/themes/no_italics/catppuccin_latte.toml
+++ b/themes/no_italics/catppuccin_latte.toml
@@ -119,6 +119,7 @@
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.info" = { underline = { color = "sky", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
 
 error = "red"
 warning = "yellow"

--- a/themes/no_italics/catppuccin_macchiato.toml
+++ b/themes/no_italics/catppuccin_macchiato.toml
@@ -119,6 +119,7 @@
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.info" = { underline = { color = "sky", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
 
 error = "red"
 warning = "yellow"

--- a/themes/no_italics/catppuccin_mocha.toml
+++ b/themes/no_italics/catppuccin_mocha.toml
@@ -119,6 +119,7 @@
 "diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
 "diagnostic.info" = { underline = { color = "sky", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
 
 error = "red"
 warning = "yellow"


### PR DESCRIPTION
Originally submitted this change to Helix [directly](https://github.com/helix-editor/helix/pull/12391). But other contributors pointed out that it would be better to make the changes to the theme here.

This change adds the dimming effect to "unnecessary" level diagnostics (e.g. unused variables).