### PR TITLE
fix: align markup syntax with vscode

### DIFF
--- a/helix.tera
+++ b/helix.tera
@@ -63,21 +63,20 @@ whiskers:
 
 "special" = "blue" # fuzzy highlight
 
-"markup.heading.marker" = { fg = "peach", modifiers = ["bold"] }
-"markup.heading.1" = "lavender"
-"markup.heading.2" = "mauve"
-"markup.heading.3" = "green"
-"markup.heading.4" = "yellow"
-"markup.heading.5" = "pink"
-"markup.heading.6" = "teal"
-"markup.list" = "mauve"
+"markup.heading.1" = "red"
+"markup.heading.2" = "peach"
+"markup.heading.3" = "yellow"
+"markup.heading.4" = "green"
+"markup.heading.5" = "blue"
+"markup.heading.6" = "mauve"
+"markup.list" = "teal"
 "markup.list.unchecked" = "overlay2"
 "markup.list.checked" = "green"
-"markup.bold" = { modifiers = ["bold"] }
-"markup.italic" = { modifiers = ["italic"] }
+"markup.bold" = { fg = "red", modifiers = ["bold"] }
+"markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue"{{ self::modifiers(other=["underlined"]) }} }
-"markup.link.text" = "blue"
-"markup.raw" = "flamingo"
+"markup.link.text" = "lavender"
+"markup.raw" = "green"
 
 "diff.plus" = "green"
 "diff.minus" = "red"

--- a/themes/default/catppuccin_frappe.toml
+++ b/themes/default/catppuccin_frappe.toml
@@ -42,21 +42,20 @@
 
 "special" = "blue" # fuzzy highlight
 
-"markup.heading.marker" = { fg = "peach", modifiers = ["bold"] }
-"markup.heading.1" = "lavender"
-"markup.heading.2" = "mauve"
-"markup.heading.3" = "green"
-"markup.heading.4" = "yellow"
-"markup.heading.5" = "pink"
-"markup.heading.6" = "teal"
-"markup.list" = "mauve"
+"markup.heading.1" = "red"
+"markup.heading.2" = "peach"
+"markup.heading.3" = "yellow"
+"markup.heading.4" = "green"
+"markup.heading.5" = "blue"
+"markup.heading.6" = "mauve"
+"markup.list" = "teal"
 "markup.list.unchecked" = "overlay2"
 "markup.list.checked" = "green"
-"markup.bold" = { modifiers = ["bold"] }
-"markup.italic" = { modifiers = ["italic"] }
+"markup.bold" = { fg = "red", modifiers = ["bold"] }
+"markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["italic", "underlined"] }
-"markup.link.text" = "blue"
-"markup.raw" = "flamingo"
+"markup.link.text" = "lavender"
+"markup.raw" = "green"
 
 "diff.plus" = "green"
 "diff.minus" = "red"

--- a/themes/default/catppuccin_latte.toml
+++ b/themes/default/catppuccin_latte.toml
@@ -42,21 +42,20 @@
 
 "special" = "blue" # fuzzy highlight
 
-"markup.heading.marker" = { fg = "peach", modifiers = ["bold"] }
-"markup.heading.1" = "lavender"
-"markup.heading.2" = "mauve"
-"markup.heading.3" = "green"
-"markup.heading.4" = "yellow"
-"markup.heading.5" = "pink"
-"markup.heading.6" = "teal"
-"markup.list" = "mauve"
+"markup.heading.1" = "red"
+"markup.heading.2" = "peach"
+"markup.heading.3" = "yellow"
+"markup.heading.4" = "green"
+"markup.heading.5" = "blue"
+"markup.heading.6" = "mauve"
+"markup.list" = "teal"
 "markup.list.unchecked" = "overlay2"
 "markup.list.checked" = "green"
-"markup.bold" = { modifiers = ["bold"] }
-"markup.italic" = { modifiers = ["italic"] }
+"markup.bold" = { fg = "red", modifiers = ["bold"] }
+"markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["italic", "underlined"] }
-"markup.link.text" = "blue"
-"markup.raw" = "flamingo"
+"markup.link.text" = "lavender"
+"markup.raw" = "green"
 
 "diff.plus" = "green"
 "diff.minus" = "red"

--- a/themes/default/catppuccin_macchiato.toml
+++ b/themes/default/catppuccin_macchiato.toml
@@ -42,21 +42,20 @@
 
 "special" = "blue" # fuzzy highlight
 
-"markup.heading.marker" = { fg = "peach", modifiers = ["bold"] }
-"markup.heading.1" = "lavender"
-"markup.heading.2" = "mauve"
-"markup.heading.3" = "green"
-"markup.heading.4" = "yellow"
-"markup.heading.5" = "pink"
-"markup.heading.6" = "teal"
-"markup.list" = "mauve"
+"markup.heading.1" = "red"
+"markup.heading.2" = "peach"
+"markup.heading.3" = "yellow"
+"markup.heading.4" = "green"
+"markup.heading.5" = "blue"
+"markup.heading.6" = "mauve"
+"markup.list" = "teal"
 "markup.list.unchecked" = "overlay2"
 "markup.list.checked" = "green"
-"markup.bold" = { modifiers = ["bold"] }
-"markup.italic" = { modifiers = ["italic"] }
+"markup.bold" = { fg = "red", modifiers = ["bold"] }
+"markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["italic", "underlined"] }
-"markup.link.text" = "blue"
-"markup.raw" = "flamingo"
+"markup.link.text" = "lavender"
+"markup.raw" = "green"
 
 "diff.plus" = "green"
 "diff.minus" = "red"

--- a/themes/default/catppuccin_mocha.toml
+++ b/themes/default/catppuccin_mocha.toml
@@ -42,21 +42,20 @@
 
 "special" = "blue" # fuzzy highlight
 
-"markup.heading.marker" = { fg = "peach", modifiers = ["bold"] }
-"markup.heading.1" = "lavender"
-"markup.heading.2" = "mauve"
-"markup.heading.3" = "green"
-"markup.heading.4" = "yellow"
-"markup.heading.5" = "pink"
-"markup.heading.6" = "teal"
-"markup.list" = "mauve"
+"markup.heading.1" = "red"
+"markup.heading.2" = "peach"
+"markup.heading.3" = "yellow"
+"markup.heading.4" = "green"
+"markup.heading.5" = "blue"
+"markup.heading.6" = "mauve"
+"markup.list" = "teal"
 "markup.list.unchecked" = "overlay2"
 "markup.list.checked" = "green"
-"markup.bold" = { modifiers = ["bold"] }
-"markup.italic" = { modifiers = ["italic"] }
+"markup.bold" = { fg = "red", modifiers = ["bold"] }
+"markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["italic", "underlined"] }
-"markup.link.text" = "blue"
-"markup.raw" = "flamingo"
+"markup.link.text" = "lavender"
+"markup.raw" = "green"
 
 "diff.plus" = "green"
 "diff.minus" = "red"

--- a/themes/no_italics/catppuccin_frappe.toml
+++ b/themes/no_italics/catppuccin_frappe.toml
@@ -42,21 +42,20 @@
 
 "special" = "blue" # fuzzy highlight
 
-"markup.heading.marker" = { fg = "peach", modifiers = ["bold"] }
-"markup.heading.1" = "lavender"
-"markup.heading.2" = "mauve"
-"markup.heading.3" = "green"
-"markup.heading.4" = "yellow"
-"markup.heading.5" = "pink"
-"markup.heading.6" = "teal"
-"markup.list" = "mauve"
+"markup.heading.1" = "red"
+"markup.heading.2" = "peach"
+"markup.heading.3" = "yellow"
+"markup.heading.4" = "green"
+"markup.heading.5" = "blue"
+"markup.heading.6" = "mauve"
+"markup.list" = "teal"
 "markup.list.unchecked" = "overlay2"
 "markup.list.checked" = "green"
-"markup.bold" = { modifiers = ["bold"] }
-"markup.italic" = { modifiers = ["italic"] }
+"markup.bold" = { fg = "red", modifiers = ["bold"] }
+"markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
-"markup.link.text" = "blue"
-"markup.raw" = "flamingo"
+"markup.link.text" = "lavender"
+"markup.raw" = "green"
 
 "diff.plus" = "green"
 "diff.minus" = "red"

--- a/themes/no_italics/catppuccin_latte.toml
+++ b/themes/no_italics/catppuccin_latte.toml
@@ -42,21 +42,20 @@
 
 "special" = "blue" # fuzzy highlight
 
-"markup.heading.marker" = { fg = "peach", modifiers = ["bold"] }
-"markup.heading.1" = "lavender"
-"markup.heading.2" = "mauve"
-"markup.heading.3" = "green"
-"markup.heading.4" = "yellow"
-"markup.heading.5" = "pink"
-"markup.heading.6" = "teal"
-"markup.list" = "mauve"
+"markup.heading.1" = "red"
+"markup.heading.2" = "peach"
+"markup.heading.3" = "yellow"
+"markup.heading.4" = "green"
+"markup.heading.5" = "blue"
+"markup.heading.6" = "mauve"
+"markup.list" = "teal"
 "markup.list.unchecked" = "overlay2"
 "markup.list.checked" = "green"
-"markup.bold" = { modifiers = ["bold"] }
-"markup.italic" = { modifiers = ["italic"] }
+"markup.bold" = { fg = "red", modifiers = ["bold"] }
+"markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
-"markup.link.text" = "blue"
-"markup.raw" = "flamingo"
+"markup.link.text" = "lavender"
+"markup.raw" = "green"
 
 "diff.plus" = "green"
 "diff.minus" = "red"

--- a/themes/no_italics/catppuccin_macchiato.toml
+++ b/themes/no_italics/catppuccin_macchiato.toml
@@ -42,21 +42,20 @@
 
 "special" = "blue" # fuzzy highlight
 
-"markup.heading.marker" = { fg = "peach", modifiers = ["bold"] }
-"markup.heading.1" = "lavender"
-"markup.heading.2" = "mauve"
-"markup.heading.3" = "green"
-"markup.heading.4" = "yellow"
-"markup.heading.5" = "pink"
-"markup.heading.6" = "teal"
-"markup.list" = "mauve"
+"markup.heading.1" = "red"
+"markup.heading.2" = "peach"
+"markup.heading.3" = "yellow"
+"markup.heading.4" = "green"
+"markup.heading.5" = "blue"
+"markup.heading.6" = "mauve"
+"markup.list" = "teal"
 "markup.list.unchecked" = "overlay2"
 "markup.list.checked" = "green"
-"markup.bold" = { modifiers = ["bold"] }
-"markup.italic" = { modifiers = ["italic"] }
+"markup.bold" = { fg = "red", modifiers = ["bold"] }
+"markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
-"markup.link.text" = "blue"
-"markup.raw" = "flamingo"
+"markup.link.text" = "lavender"
+"markup.raw" = "green"
 
 "diff.plus" = "green"
 "diff.minus" = "red"

--- a/themes/no_italics/catppuccin_mocha.toml
+++ b/themes/no_italics/catppuccin_mocha.toml
@@ -42,21 +42,20 @@
 
 "special" = "blue" # fuzzy highlight
 
-"markup.heading.marker" = { fg = "peach", modifiers = ["bold"] }
-"markup.heading.1" = "lavender"
-"markup.heading.2" = "mauve"
-"markup.heading.3" = "green"
-"markup.heading.4" = "yellow"
-"markup.heading.5" = "pink"
-"markup.heading.6" = "teal"
-"markup.list" = "mauve"
+"markup.heading.1" = "red"
+"markup.heading.2" = "peach"
+"markup.heading.3" = "yellow"
+"markup.heading.4" = "green"
+"markup.heading.5" = "blue"
+"markup.heading.6" = "mauve"
+"markup.list" = "teal"
 "markup.list.unchecked" = "overlay2"
 "markup.list.checked" = "green"
-"markup.bold" = { modifiers = ["bold"] }
-"markup.italic" = { modifiers = ["italic"] }
+"markup.bold" = { fg = "red", modifiers = ["bold"] }
+"markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
-"markup.link.text" = "blue"
-"markup.raw" = "flamingo"
+"markup.link.text" = "lavender"
+"markup.raw" = "green"
 
 "diff.plus" = "green"
 "diff.minus" = "red"


### PR DESCRIPTION
- Adjusts the numbered `markup.heading` colors to align with VSCode's numbered markdown heading colors, and removed the `markup.heading.marker` styling that should instead by supplied by the numbered `markup.heading` capture. This technically depends on https://github.com/helix-editor/helix/pull/12417 upstream at Helix.

| Before | After |
| --- | --- |
| ![CleanShot 2025-01-05 at 15 56 41](https://github.com/user-attachments/assets/1bf40795-5d82-4c64-8348-cc7912d401a2) | ![CleanShot 2025-01-05 at 15 46 29](https://github.com/user-attachments/assets/e3323aaf-51aa-4706-967c-6066bcf62f8c) |

- Changes `markup.list` from mauve to teal (numbered lists in markdown such as `1. foo 2. bar`).

| Before | After |
| --- | --- |
| ![CleanShot 2025-01-05 at 15 56 09](https://github.com/user-attachments/assets/e72f72f4-7fca-480e-892f-a2e5270c347b) | ![CleanShot 2025-01-05 at 15 44 26](https://github.com/user-attachments/assets/71077566-699d-48b0-8cac-6d5b3927f485) |

- `markup.bold` and `markup.italic` are now red as well as their previous styles (italic and bold text ofc).

| Before | After |
| --- | --- |
| ![CleanShot 2025-01-05 at 15 55 06](https://github.com/user-attachments/assets/88e98a06-1c06-4275-9c5d-c85cfb0d4328) | ![CleanShot 2025-01-05 at 15 43 26](https://github.com/user-attachments/assets/3387d018-ad45-4fe2-bbfe-6a1a05d90d09) |

- `markup.link.text`, the title of links in markdown, is now lavender instead of blue.

| Before | After |
| --- | --- |
| ![CleanShot 2025-01-05 at 15 55 32](https://github.com/user-attachments/assets/51c43bed-6cd4-4e0f-bfec-9b4cfa9ab085) | ![CleanShot 2025-01-05 at 15 44 56](https://github.com/user-attachments/assets/c341fe98-08c6-42c3-95b1-6124bc3261e0) |

- `markup.raw` is green instead of flamingo.

| Before | After |
| --- | --- |
| ![CleanShot 2025-01-05 at 15 57 07](https://github.com/user-attachments/assets/d1777bed-a6ff-44ea-b377-eaee97df7256) | 
![CleanShot 2025-01-05 at 15 45 58](https://github.com/user-attachments/assets/f2751183-dd3e-4119-9b3f-1500ecec564f) |