### PR TITLE
fix: use vscode's inlay hint colors

### DIFF
--- a/helix.tera
+++ b/helix.tera
@@ -112,7 +112,9 @@ whiskers:
 "ui.virtual" = "overlay0"
 "ui.virtual.ruler" = { bg = "surface0" }
 "ui.virtual.indent-guide" = "surface0"
-"ui.virtual.inlay-hint" = { fg = "surface1", bg = "mantle" }
+"ui.virtual.inlay-hint" = { fg = "surface2", bg = "mantle" }
+"ui.virtual.inlay-hint.parameter" = "subtext0"
+"ui.virtual.inlay-hint.type" = "subtext1"
 "ui.virtual.jump-label" = { fg = "rosewater", modifiers = ["bold"] }
 
 "ui.selection" = { bg = "surface1" }


### PR DESCRIPTION
See https://github.com/catppuccin/vscode/blob/7b0ff73aa9e9718cbe418a3f90f771aa14a655b8/packages/catppuccin-vsc/src/theme/uiColors.ts#L181-L186. Left the background as mantle still, though in VS Code it is mantle *with a 75% opacity* - I don't think Helix supports hex colors with opacity at the end.