### PR TITLE
feat: change color of `special` to align with Neovim

### DIFF
--- a/helix.tera
+++ b/helix.tera
@@ -34,7 +34,7 @@ whiskers:
 
 "string" = "green"
 "string.regexp" = "pink"
-"string.special" = "blue"
+"string.special" = "pink"
 "string.special.symbol" = "red"
 
 "comment" = { fg = "overlay2"{{ self::modifiers() }} }

--- a/themes/default/catppuccin_frappe.toml
+++ b/themes/default/catppuccin_frappe.toml
@@ -13,7 +13,7 @@
 
 "string" = "green"
 "string.regexp" = "pink"
-"string.special" = "blue"
+"string.special" = "pink"
 "string.special.symbol" = "red"
 
 "comment" = { fg = "overlay2", modifiers = ["italic"] }

--- a/themes/default/catppuccin_latte.toml
+++ b/themes/default/catppuccin_latte.toml
@@ -13,7 +13,7 @@
 
 "string" = "green"
 "string.regexp" = "pink"
-"string.special" = "blue"
+"string.special" = "pink"
 "string.special.symbol" = "red"
 
 "comment" = { fg = "overlay2", modifiers = ["italic"] }

--- a/themes/default/catppuccin_macchiato.toml
+++ b/themes/default/catppuccin_macchiato.toml
@@ -13,7 +13,7 @@
 
 "string" = "green"
 "string.regexp" = "pink"
-"string.special" = "blue"
+"string.special" = "pink"
 "string.special.symbol" = "red"
 
 "comment" = { fg = "overlay2", modifiers = ["italic"] }

--- a/themes/default/catppuccin_mocha.toml
+++ b/themes/default/catppuccin_mocha.toml
@@ -13,7 +13,7 @@
 
 "string" = "green"
 "string.regexp" = "pink"
-"string.special" = "blue"
+"string.special" = "pink"
 "string.special.symbol" = "red"
 
 "comment" = { fg = "overlay2", modifiers = ["italic"] }

--- a/themes/no_italics/catppuccin_frappe.toml
+++ b/themes/no_italics/catppuccin_frappe.toml
@@ -13,7 +13,7 @@
 
 "string" = "green"
 "string.regexp" = "pink"
-"string.special" = "blue"
+"string.special" = "pink"
 "string.special.symbol" = "red"
 
 "comment" = { fg = "overlay2" }

--- a/themes/no_italics/catppuccin_latte.toml
+++ b/themes/no_italics/catppuccin_latte.toml
@@ -13,7 +13,7 @@
 
 "string" = "green"
 "string.regexp" = "pink"
-"string.special" = "blue"
+"string.special" = "pink"
 "string.special.symbol" = "red"
 
 "comment" = { fg = "overlay2" }

--- a/themes/no_italics/catppuccin_macchiato.toml
+++ b/themes/no_italics/catppuccin_macchiato.toml
@@ -13,7 +13,7 @@
 
 "string" = "green"
 "string.regexp" = "pink"
-"string.special" = "blue"
+"string.special" = "pink"
 "string.special.symbol" = "red"
 
 "comment" = { fg = "overlay2" }

--- a/themes/no_italics/catppuccin_mocha.toml
+++ b/themes/no_italics/catppuccin_mocha.toml
@@ -13,7 +13,7 @@
 
 "string" = "green"
 "string.regexp" = "pink"
-"string.special" = "blue"
+"string.special" = "pink"
 "string.special.symbol" = "red"
 
 "comment" = { fg = "overlay2" }


### PR DESCRIPTION
[Aligns more with `Neovim`](https://github.com/catppuccin/nvim/blob/main/lua/catppuccin/groups/syntax.lua#L31)