### PR TITLE
fix: use `rosewater` for cursors

### DIFF
--- a/helix.tera
+++ b/helix.tera
@@ -118,7 +118,7 @@ whiskers:
 "ui.cursor.primary" = { fg = "base", bg = "rosewater" }
 "ui.cursor.match" = { fg = "peach", modifiers = ["bold"] }
 
-"ui.cursor.primary.normal" = { fg = "base", bg = "lavender" }
+"ui.cursor.primary.normal" = { fg = "base", bg = "rosewater" }
 "ui.cursor.primary.insert" = { fg = "base", bg = "green" }
 "ui.cursor.primary.select" = { fg = "base", bg = "flamingo" }
 
@@ -150,5 +150,5 @@ hint = "teal"
 
 cursorline = "#{% if flavor.dark %}{{ surface0 | mix(color=base, amount=0.64) | get(key="hex") }}{% else %}{{ mantle | mix(color=base, amount=0.7) | get(key="hex") }}{% endif %}"
 secondary_cursor = "#{{ rosewater | mix(color=base, amount=0.7) | get(key="hex") }}"
-secondary_cursor_normal = "#{{ lavender | mix(color=base, amount=0.7) | get(key="hex") }}"
+secondary_cursor_normal = "#{{ rosewater | mix(color=base, amount=0.7) | get(key="hex") }}"
 secondary_cursor_insert = "#{{ green | mix(color=base, amount=0.7) | get(key="hex") }}"

--- a/themes/default/catppuccin_frappe.toml
+++ b/themes/default/catppuccin_frappe.toml
@@ -97,7 +97,7 @@
 "ui.cursor.primary" = { fg = "base", bg = "rosewater" }
 "ui.cursor.match" = { fg = "peach", modifiers = ["bold"] }
 
-"ui.cursor.primary.normal" = { fg = "base", bg = "lavender" }
+"ui.cursor.primary.normal" = { fg = "base", bg = "rosewater" }
 "ui.cursor.primary.insert" = { fg = "base", bg = "green" }
 "ui.cursor.primary.select" = { fg = "base", bg = "flamingo" }
 
@@ -152,5 +152,5 @@ crust = "#232634"
 
 cursorline = "#3b3f52"
 secondary_cursor = "#b8a5a6"
-secondary_cursor_normal = "#9192be"
+secondary_cursor_normal = "#b8a5a6"
 secondary_cursor_insert = "#83a275"

--- a/themes/default/catppuccin_latte.toml
+++ b/themes/default/catppuccin_latte.toml
@@ -97,7 +97,7 @@
 "ui.cursor.primary" = { fg = "base", bg = "rosewater" }
 "ui.cursor.match" = { fg = "peach", modifiers = ["bold"] }
 
-"ui.cursor.primary.normal" = { fg = "base", bg = "lavender" }
+"ui.cursor.primary.normal" = { fg = "base", bg = "rosewater" }
 "ui.cursor.primary.insert" = { fg = "base", bg = "green" }
 "ui.cursor.primary.select" = { fg = "base", bg = "flamingo" }
 
@@ -152,5 +152,5 @@ crust = "#dce0e8"
 
 cursorline = "#e8ecf1"
 secondary_cursor = "#e1a99d"
-secondary_cursor_normal = "#97a7fb"
+secondary_cursor_normal = "#e1a99d"
 secondary_cursor_insert = "#74b867"

--- a/themes/default/catppuccin_macchiato.toml
+++ b/themes/default/catppuccin_macchiato.toml
@@ -97,7 +97,7 @@
 "ui.cursor.primary" = { fg = "base", bg = "rosewater" }
 "ui.cursor.match" = { fg = "peach", modifiers = ["bold"] }
 
-"ui.cursor.primary.normal" = { fg = "base", bg = "lavender" }
+"ui.cursor.primary.normal" = { fg = "base", bg = "rosewater" }
 "ui.cursor.primary.insert" = { fg = "base", bg = "green" }
 "ui.cursor.primary.select" = { fg = "base", bg = "flamingo" }
 
@@ -152,5 +152,5 @@ crust = "#181926"
 
 cursorline = "#303347"
 secondary_cursor = "#b6a6a7"
-secondary_cursor_normal = "#8b91bf"
+secondary_cursor_normal = "#b6a6a7"
 secondary_cursor_insert = "#80a57a"

--- a/themes/default/catppuccin_mocha.toml
+++ b/themes/default/catppuccin_mocha.toml
@@ -97,7 +97,7 @@
 "ui.cursor.primary" = { fg = "base", bg = "rosewater" }
 "ui.cursor.match" = { fg = "peach", modifiers = ["bold"] }
 
-"ui.cursor.primary.normal" = { fg = "base", bg = "lavender" }
+"ui.cursor.primary.normal" = { fg = "base", bg = "rosewater" }
 "ui.cursor.primary.insert" = { fg = "base", bg = "green" }
 "ui.cursor.primary.select" = { fg = "base", bg = "flamingo" }
 
@@ -152,5 +152,5 @@ crust = "#11111b"
 
 cursorline = "#2a2b3c"
 secondary_cursor = "#b5a6a8"
-secondary_cursor_normal = "#878ec0"
+secondary_cursor_normal = "#b5a6a8"
 secondary_cursor_insert = "#7ea87f"

--- a/themes/no_italics/catppuccin_frappe.toml
+++ b/themes/no_italics/catppuccin_frappe.toml
@@ -97,7 +97,7 @@
 "ui.cursor.primary" = { fg = "base", bg = "rosewater" }
 "ui.cursor.match" = { fg = "peach", modifiers = ["bold"] }
 
-"ui.cursor.primary.normal" = { fg = "base", bg = "lavender" }
+"ui.cursor.primary.normal" = { fg = "base", bg = "rosewater" }
 "ui.cursor.primary.insert" = { fg = "base", bg = "green" }
 "ui.cursor.primary.select" = { fg = "base", bg = "flamingo" }
 
@@ -152,5 +152,5 @@ crust = "#232634"
 
 cursorline = "#3b3f52"
 secondary_cursor = "#b8a5a6"
-secondary_cursor_normal = "#9192be"
+secondary_cursor_normal = "#b8a5a6"
 secondary_cursor_insert = "#83a275"

--- a/themes/no_italics/catppuccin_latte.toml
+++ b/themes/no_italics/catppuccin_latte.toml
@@ -97,7 +97,7 @@
 "ui.cursor.primary" = { fg = "base", bg = "rosewater" }
 "ui.cursor.match" = { fg = "peach", modifiers = ["bold"] }
 
-"ui.cursor.primary.normal" = { fg = "base", bg = "lavender" }
+"ui.cursor.primary.normal" = { fg = "base", bg = "rosewater" }
 "ui.cursor.primary.insert" = { fg = "base", bg = "green" }
 "ui.cursor.primary.select" = { fg = "base", bg = "flamingo" }
 
@@ -152,5 +152,5 @@ crust = "#dce0e8"
 
 cursorline = "#e8ecf1"
 secondary_cursor = "#e1a99d"
-secondary_cursor_normal = "#97a7fb"
+secondary_cursor_normal = "#e1a99d"
 secondary_cursor_insert = "#74b867"

--- a/themes/no_italics/catppuccin_macchiato.toml
+++ b/themes/no_italics/catppuccin_macchiato.toml
@@ -97,7 +97,7 @@
 "ui.cursor.primary" = { fg = "base", bg = "rosewater" }
 "ui.cursor.match" = { fg = "peach", modifiers = ["bold"] }
 
-"ui.cursor.primary.normal" = { fg = "base", bg = "lavender" }
+"ui.cursor.primary.normal" = { fg = "base", bg = "rosewater" }
 "ui.cursor.primary.insert" = { fg = "base", bg = "green" }
 "ui.cursor.primary.select" = { fg = "base", bg = "flamingo" }
 
@@ -152,5 +152,5 @@ crust = "#181926"
 
 cursorline = "#303347"
 secondary_cursor = "#b6a6a7"
-secondary_cursor_normal = "#8b91bf"
+secondary_cursor_normal = "#b6a6a7"
 secondary_cursor_insert = "#80a57a"

--- a/themes/no_italics/catppuccin_mocha.toml
+++ b/themes/no_italics/catppuccin_mocha.toml
@@ -97,7 +97,7 @@
 "ui.cursor.primary" = { fg = "base", bg = "rosewater" }
 "ui.cursor.match" = { fg = "peach", modifiers = ["bold"] }
 
-"ui.cursor.primary.normal" = { fg = "base", bg = "lavender" }
+"ui.cursor.primary.normal" = { fg = "base", bg = "rosewater" }
 "ui.cursor.primary.insert" = { fg = "base", bg = "green" }
 "ui.cursor.primary.select" = { fg = "base", bg = "flamingo" }
 
@@ -152,5 +152,5 @@ crust = "#11111b"
 
 cursorline = "#2a2b3c"
 secondary_cursor = "#b5a6a8"
-secondary_cursor_normal = "#878ec0"
+secondary_cursor_normal = "#b5a6a8"
 secondary_cursor_insert = "#7ea87f"


### PR DESCRIPTION
This PR makes the cursors the same color as what they should be which is rosewater (in normal mode)

The theme already sets `ui.cursor` and `ui.cursor.primary`, however these **don't actually get used** because Helix uses the more specific `ui.cursor.normal` and `ui.cursor.primary.normal`.

So now, in normal mode the cursor will be rosewater 