### PR TITLE
feat: Add color for link labels

### DIFF
--- a/helix.tera
+++ b/helix.tera
@@ -76,6 +76,7 @@ whiskers:
 "markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue"{{ self::modifiers(other=["underlined"]) }} }
 "markup.link.text" = "lavender"
+"markup.link.label" = "sapphire"
 "markup.raw" = "green"
 "markup.quote" = "pink"
 

--- a/themes/default/catppuccin_frappe.toml
+++ b/themes/default/catppuccin_frappe.toml
@@ -55,6 +55,7 @@
 "markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["italic", "underlined"] }
 "markup.link.text" = "lavender"
+"markup.link.label" = "sapphire"
 "markup.raw" = "green"
 "markup.quote" = "pink"
 

--- a/themes/default/catppuccin_latte.toml
+++ b/themes/default/catppuccin_latte.toml
@@ -55,6 +55,7 @@
 "markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["italic", "underlined"] }
 "markup.link.text" = "lavender"
+"markup.link.label" = "sapphire"
 "markup.raw" = "green"
 "markup.quote" = "pink"
 

--- a/themes/default/catppuccin_macchiato.toml
+++ b/themes/default/catppuccin_macchiato.toml
@@ -55,6 +55,7 @@
 "markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["italic", "underlined"] }
 "markup.link.text" = "lavender"
+"markup.link.label" = "sapphire"
 "markup.raw" = "green"
 "markup.quote" = "pink"
 

--- a/themes/default/catppuccin_mocha.toml
+++ b/themes/default/catppuccin_mocha.toml
@@ -55,6 +55,7 @@
 "markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["italic", "underlined"] }
 "markup.link.text" = "lavender"
+"markup.link.label" = "sapphire"
 "markup.raw" = "green"
 "markup.quote" = "pink"
 

--- a/themes/no_italics/catppuccin_frappe.toml
+++ b/themes/no_italics/catppuccin_frappe.toml
@@ -55,6 +55,7 @@
 "markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
 "markup.link.text" = "lavender"
+"markup.link.label" = "sapphire"
 "markup.raw" = "green"
 "markup.quote" = "pink"
 

--- a/themes/no_italics/catppuccin_latte.toml
+++ b/themes/no_italics/catppuccin_latte.toml
@@ -55,6 +55,7 @@
 "markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
 "markup.link.text" = "lavender"
+"markup.link.label" = "sapphire"
 "markup.raw" = "green"
 "markup.quote" = "pink"
 

--- a/themes/no_italics/catppuccin_macchiato.toml
+++ b/themes/no_italics/catppuccin_macchiato.toml
@@ -55,6 +55,7 @@
 "markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
 "markup.link.text" = "lavender"
+"markup.link.label" = "sapphire"
 "markup.raw" = "green"
 "markup.quote" = "pink"
 

--- a/themes/no_italics/catppuccin_mocha.toml
+++ b/themes/no_italics/catppuccin_mocha.toml
@@ -55,6 +55,7 @@
 "markup.italic" = { fg = "red", modifiers = ["italic"] }
 "markup.link.url" = { fg = "blue", modifiers = ["underlined"] }
 "markup.link.text" = "lavender"
+"markup.link.label" = "sapphire"
 "markup.raw" = "green"
 "markup.quote" = "pink"
 


### PR DESCRIPTION
Since these are labels I'm using the same color as `label`. I think it shouldn't be styled the same color as inline links because that is potentially confusing, at a glance it may look like these links are paragraphs when they aren't

## before

![image](https://github.com/user-attachments/assets/2f408846-c40b-4376-9147-7e89b519ddce)

## after

![image](https://github.com/user-attachments/assets/5bd3def7-f9d1-46d6-afe1-860ce8e3cba2)
