### PR TITLE
fix: use `rosewater` color for macros

### DIFF
--- a/helix.tera
+++ b/helix.tera
@@ -55,7 +55,7 @@ whiskers:
 "operator" = "sky"
 
 "function" = "blue"
-"function.macro" = "mauve"
+"function.macro" = "rosewater"
 
 "tag" = "blue"
 

--- a/themes/default/catppuccin_frappe.toml
+++ b/themes/default/catppuccin_frappe.toml
@@ -34,7 +34,7 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.macro" = "mauve"
+"function.macro" = "rosewater"
 
 "tag" = "blue"
 

--- a/themes/default/catppuccin_latte.toml
+++ b/themes/default/catppuccin_latte.toml
@@ -34,7 +34,7 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.macro" = "mauve"
+"function.macro" = "rosewater"
 
 "tag" = "blue"
 

--- a/themes/default/catppuccin_macchiato.toml
+++ b/themes/default/catppuccin_macchiato.toml
@@ -34,7 +34,7 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.macro" = "mauve"
+"function.macro" = "rosewater"
 
 "tag" = "blue"
 

--- a/themes/default/catppuccin_mocha.toml
+++ b/themes/default/catppuccin_mocha.toml
@@ -34,7 +34,7 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.macro" = "mauve"
+"function.macro" = "rosewater"
 
 "tag" = "blue"
 

--- a/themes/no_italics/catppuccin_frappe.toml
+++ b/themes/no_italics/catppuccin_frappe.toml
@@ -34,7 +34,7 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.macro" = "mauve"
+"function.macro" = "rosewater"
 
 "tag" = "blue"
 

--- a/themes/no_italics/catppuccin_latte.toml
+++ b/themes/no_italics/catppuccin_latte.toml
@@ -34,7 +34,7 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.macro" = "mauve"
+"function.macro" = "rosewater"
 
 "tag" = "blue"
 

--- a/themes/no_italics/catppuccin_macchiato.toml
+++ b/themes/no_italics/catppuccin_macchiato.toml
@@ -34,7 +34,7 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.macro" = "mauve"
+"function.macro" = "rosewater"
 
 "tag" = "blue"
 

--- a/themes/no_italics/catppuccin_mocha.toml
+++ b/themes/no_italics/catppuccin_mocha.toml
@@ -34,7 +34,7 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.macro" = "mauve"
+"function.macro" = "rosewater"
 
 "tag" = "blue"
 


### PR DESCRIPTION
[as is defined in the style guide](https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md)