### PR TITLE
fix: use `lavender` for secondary cursor in visual mode

### DIFF
--- a/helix.tera
+++ b/helix.tera
@@ -128,7 +128,7 @@ whiskers:
 
 "ui.cursor.normal" = { fg = "base", bg = "secondary_cursor_normal" }
 "ui.cursor.insert" = { fg = "base", bg = "secondary_cursor_insert" }
-"ui.cursor.select" = { fg = "base", bg = "secondary_cursor" }
+"ui.cursor.select" = { fg = "base", bg = "secondary_cursor_select" }
 
 "ui.cursorline.primary" = { bg = "cursorline" }
 
@@ -155,5 +155,6 @@ hint = "teal"
 
 cursorline = "#{% if flavor.dark %}{{ surface0 | mix(color=base, amount=0.64) | get(key="hex") }}{% else %}{{ mantle | mix(color=base, amount=0.7) | get(key="hex") }}{% endif %}"
 secondary_cursor = "#{{ rosewater | mix(color=base, amount=0.7) | get(key="hex") }}"
+secondary_cursor_select = "#{{ lavender | mix(color=base, amount=0.7) | get(key="hex") }}"
 secondary_cursor_normal = "#{{ rosewater | mix(color=base, amount=0.7) | get(key="hex") }}"
 secondary_cursor_insert = "#{{ green | mix(color=base, amount=0.7) | get(key="hex") }}"

--- a/themes/default/catppuccin_frappe.toml
+++ b/themes/default/catppuccin_frappe.toml
@@ -107,7 +107,7 @@
 
 "ui.cursor.normal" = { fg = "base", bg = "secondary_cursor_normal" }
 "ui.cursor.insert" = { fg = "base", bg = "secondary_cursor_insert" }
-"ui.cursor.select" = { fg = "base", bg = "secondary_cursor" }
+"ui.cursor.select" = { fg = "base", bg = "secondary_cursor_select" }
 
 "ui.cursorline.primary" = { bg = "cursorline" }
 
@@ -157,5 +157,6 @@ crust = "#232634"
 
 cursorline = "#3b3f52"
 secondary_cursor = "#b8a5a6"
+secondary_cursor_select = "#9192be"
 secondary_cursor_normal = "#b8a5a6"
 secondary_cursor_insert = "#83a275"

--- a/themes/default/catppuccin_latte.toml
+++ b/themes/default/catppuccin_latte.toml
@@ -107,7 +107,7 @@
 
 "ui.cursor.normal" = { fg = "base", bg = "secondary_cursor_normal" }
 "ui.cursor.insert" = { fg = "base", bg = "secondary_cursor_insert" }
-"ui.cursor.select" = { fg = "base", bg = "secondary_cursor" }
+"ui.cursor.select" = { fg = "base", bg = "secondary_cursor_select" }
 
 "ui.cursorline.primary" = { bg = "cursorline" }
 
@@ -157,5 +157,6 @@ crust = "#dce0e8"
 
 cursorline = "#e8ecf1"
 secondary_cursor = "#e1a99d"
+secondary_cursor_select = "#97a7fb"
 secondary_cursor_normal = "#e1a99d"
 secondary_cursor_insert = "#74b867"

--- a/themes/default/catppuccin_macchiato.toml
+++ b/themes/default/catppuccin_macchiato.toml
@@ -107,7 +107,7 @@
 
 "ui.cursor.normal" = { fg = "base", bg = "secondary_cursor_normal" }
 "ui.cursor.insert" = { fg = "base", bg = "secondary_cursor_insert" }
-"ui.cursor.select" = { fg = "base", bg = "secondary_cursor" }
+"ui.cursor.select" = { fg = "base", bg = "secondary_cursor_select" }
 
 "ui.cursorline.primary" = { bg = "cursorline" }
 
@@ -157,5 +157,6 @@ crust = "#181926"
 
 cursorline = "#303347"
 secondary_cursor = "#b6a6a7"
+secondary_cursor_select = "#8b91bf"
 secondary_cursor_normal = "#b6a6a7"
 secondary_cursor_insert = "#80a57a"

--- a/themes/default/catppuccin_mocha.toml
+++ b/themes/default/catppuccin_mocha.toml
@@ -107,7 +107,7 @@
 
 "ui.cursor.normal" = { fg = "base", bg = "secondary_cursor_normal" }
 "ui.cursor.insert" = { fg = "base", bg = "secondary_cursor_insert" }
-"ui.cursor.select" = { fg = "base", bg = "secondary_cursor" }
+"ui.cursor.select" = { fg = "base", bg = "secondary_cursor_select" }
 
 "ui.cursorline.primary" = { bg = "cursorline" }
 
@@ -157,5 +157,6 @@ crust = "#11111b"
 
 cursorline = "#2a2b3c"
 secondary_cursor = "#b5a6a8"
+secondary_cursor_select = "#878ec0"
 secondary_cursor_normal = "#b5a6a8"
 secondary_cursor_insert = "#7ea87f"

--- a/themes/no_italics/catppuccin_frappe.toml
+++ b/themes/no_italics/catppuccin_frappe.toml
@@ -107,7 +107,7 @@
 
 "ui.cursor.normal" = { fg = "base", bg = "secondary_cursor_normal" }
 "ui.cursor.insert" = { fg = "base", bg = "secondary_cursor_insert" }
-"ui.cursor.select" = { fg = "base", bg = "secondary_cursor" }
+"ui.cursor.select" = { fg = "base", bg = "secondary_cursor_select" }
 
 "ui.cursorline.primary" = { bg = "cursorline" }
 
@@ -157,5 +157,6 @@ crust = "#232634"
 
 cursorline = "#3b3f52"
 secondary_cursor = "#b8a5a6"
+secondary_cursor_select = "#9192be"
 secondary_cursor_normal = "#b8a5a6"
 secondary_cursor_insert = "#83a275"

--- a/themes/no_italics/catppuccin_latte.toml
+++ b/themes/no_italics/catppuccin_latte.toml
@@ -107,7 +107,7 @@
 
 "ui.cursor.normal" = { fg = "base", bg = "secondary_cursor_normal" }
 "ui.cursor.insert" = { fg = "base", bg = "secondary_cursor_insert" }
-"ui.cursor.select" = { fg = "base", bg = "secondary_cursor" }
+"ui.cursor.select" = { fg = "base", bg = "secondary_cursor_select" }
 
 "ui.cursorline.primary" = { bg = "cursorline" }
 
@@ -157,5 +157,6 @@ crust = "#dce0e8"
 
 cursorline = "#e8ecf1"
 secondary_cursor = "#e1a99d"
+secondary_cursor_select = "#97a7fb"
 secondary_cursor_normal = "#e1a99d"
 secondary_cursor_insert = "#74b867"

--- a/themes/no_italics/catppuccin_macchiato.toml
+++ b/themes/no_italics/catppuccin_macchiato.toml
@@ -107,7 +107,7 @@
 
 "ui.cursor.normal" = { fg = "base", bg = "secondary_cursor_normal" }
 "ui.cursor.insert" = { fg = "base", bg = "secondary_cursor_insert" }
-"ui.cursor.select" = { fg = "base", bg = "secondary_cursor" }
+"ui.cursor.select" = { fg = "base", bg = "secondary_cursor_select" }
 
 "ui.cursorline.primary" = { bg = "cursorline" }
 
@@ -157,5 +157,6 @@ crust = "#181926"
 
 cursorline = "#303347"
 secondary_cursor = "#b6a6a7"
+secondary_cursor_select = "#8b91bf"
 secondary_cursor_normal = "#b6a6a7"
 secondary_cursor_insert = "#80a57a"

--- a/themes/no_italics/catppuccin_mocha.toml
+++ b/themes/no_italics/catppuccin_mocha.toml
@@ -107,7 +107,7 @@
 
 "ui.cursor.normal" = { fg = "base", bg = "secondary_cursor_normal" }
 "ui.cursor.insert" = { fg = "base", bg = "secondary_cursor_insert" }
-"ui.cursor.select" = { fg = "base", bg = "secondary_cursor" }
+"ui.cursor.select" = { fg = "base", bg = "secondary_cursor_select" }
 
 "ui.cursorline.primary" = { bg = "cursorline" }
 
@@ -157,5 +157,6 @@ crust = "#11111b"
 
 cursorline = "#2a2b3c"
 secondary_cursor = "#b5a6a8"
+secondary_cursor_select = "#878ec0"
 secondary_cursor_normal = "#b5a6a8"
 secondary_cursor_insert = "#7ea87f"


### PR DESCRIPTION
secondary cursors should change their color in select mode

to test:

1. select several lines
2. use `alt-s` to have a separate selection on each line
3. go into visual mode `v`

## before

the primary cursor is `lavender` but the rest are `rosewater`

![image](https://github.com/user-attachments/assets/03120760-b8bf-4125-bd7e-0de1d5123af1)

## after

all cursors are `lavender`

![image](https://github.com/user-attachments/assets/417e8cec-b83d-4bc3-a593-4055623fc345)
