### PR TITLE
feat: add rainbow key

### DIFF
--- a/helix.tera
+++ b/helix.tera
@@ -148,6 +148,8 @@ warning = "yellow"
 info = "sky"
 hint = "teal"
 
+rainbow = ["red", "peach", "yellow", "green", "sapphire", "lavender"]
+
 [palette]
 {%- for identifier, color in flavor.colors %}
 {{ identifier }} = "#{{ color.hex }}"

--- a/themes/default/catppuccin_frappe.toml
+++ b/themes/default/catppuccin_frappe.toml
@@ -127,6 +127,8 @@ warning = "yellow"
 info = "sky"
 hint = "teal"
 
+rainbow = ["red", "peach", "yellow", "green", "sapphire", "lavender"]
+
 [palette]
 rosewater = "#f2d5cf"
 flamingo = "#eebebe"

--- a/themes/default/catppuccin_latte.toml
+++ b/themes/default/catppuccin_latte.toml
@@ -127,6 +127,8 @@ warning = "yellow"
 info = "sky"
 hint = "teal"
 
+rainbow = ["red", "peach", "yellow", "green", "sapphire", "lavender"]
+
 [palette]
 rosewater = "#dc8a78"
 flamingo = "#dd7878"

--- a/themes/default/catppuccin_macchiato.toml
+++ b/themes/default/catppuccin_macchiato.toml
@@ -127,6 +127,8 @@ warning = "yellow"
 info = "sky"
 hint = "teal"
 
+rainbow = ["red", "peach", "yellow", "green", "sapphire", "lavender"]
+
 [palette]
 rosewater = "#f4dbd6"
 flamingo = "#f0c6c6"

--- a/themes/default/catppuccin_mocha.toml
+++ b/themes/default/catppuccin_mocha.toml
@@ -127,6 +127,8 @@ warning = "yellow"
 info = "sky"
 hint = "teal"
 
+rainbow = ["red", "peach", "yellow", "green", "sapphire", "lavender"]
+
 [palette]
 rosewater = "#f5e0dc"
 flamingo = "#f2cdcd"

--- a/themes/no_italics/catppuccin_frappe.toml
+++ b/themes/no_italics/catppuccin_frappe.toml
@@ -127,6 +127,8 @@ warning = "yellow"
 info = "sky"
 hint = "teal"
 
+rainbow = ["red", "peach", "yellow", "green", "sapphire", "lavender"]
+
 [palette]
 rosewater = "#f2d5cf"
 flamingo = "#eebebe"

--- a/themes/no_italics/catppuccin_latte.toml
+++ b/themes/no_italics/catppuccin_latte.toml
@@ -127,6 +127,8 @@ warning = "yellow"
 info = "sky"
 hint = "teal"
 
+rainbow = ["red", "peach", "yellow", "green", "sapphire", "lavender"]
+
 [palette]
 rosewater = "#dc8a78"
 flamingo = "#dd7878"

--- a/themes/no_italics/catppuccin_macchiato.toml
+++ b/themes/no_italics/catppuccin_macchiato.toml
@@ -127,6 +127,8 @@ warning = "yellow"
 info = "sky"
 hint = "teal"
 
+rainbow = ["red", "peach", "yellow", "green", "sapphire", "lavender"]
+
 [palette]
 rosewater = "#f4dbd6"
 flamingo = "#f0c6c6"

--- a/themes/no_italics/catppuccin_mocha.toml
+++ b/themes/no_italics/catppuccin_mocha.toml
@@ -127,6 +127,8 @@ warning = "yellow"
 info = "sky"
 hint = "teal"
 
+rainbow = ["red", "peach", "yellow", "green", "sapphire", "lavender"]
+
 [palette]
 rosewater = "#f5e0dc"
 flamingo = "#f2cdcd"


### PR DESCRIPTION
Helix has just merged [a PR](https://github.com/helix-editor/helix/pull/13530) that adds Rainbow highlighting the requires a new `rainbow` key.